### PR TITLE
Frontend: Roles/Candidates/Account + API Compatibility + Signed File Access (v3)

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,3 +1,4 @@
+// chore: mvp-hardening-frontend-v3 (no-op)
 // src/lib/api.js
 import { supabase } from './supabaseClient'
 

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,15 +1,29 @@
 // src/lib/api.js
+import { supabase } from './supabaseClient'
+
 const base = (import.meta.env.VITE_BACKEND_URL || '').replace(/\/+$/, '')
 
-async function authHeader(getToken) {
-  const token = await getToken?.()
+async function getToken() {
+  const { data } = await supabase.auth.getSession()
+  return data?.session?.access_token || null
+}
+
+async function authHeader() {
+  const token = await getToken()
   return token ? { Authorization: `Bearer ${token}` } : {}
 }
-async function fetchJSON(path, { method = 'GET', body, headers = {}, getToken } = {}) {
-  const url = `${base}${path.startsWith('/') ? path : `/${path}`}`
+
+function fullUrl(path) {
+  if (!path) return base
+  if (/^https?:\/\//i.test(path)) return path
+  return `${base}${path.startsWith('/') ? path : `/${path}`}`
+}
+
+async function fetchJSON(path, { method = 'GET', body, headers = {} } = {}) {
+  const url = fullUrl(path)
   const h = {
     'Content-Type': 'application/json',
-    ...(await authHeader(getToken)),
+    ...(await authHeader()),
     ...headers,
   }
   const res = await fetch(url, { method, headers: h, body: body ? JSON.stringify(body) : undefined })
@@ -22,50 +36,55 @@ async function fetchJSON(path, { method = 'GET', body, headers = {}, getToken } 
   return ct.includes('application/json') ? res.json() : res.text()
 }
 
+/* -------- Legacy helpers exported for backward compatibility -------- */
+export async function apiGet(path) {
+  return fetchJSON(path, { method: 'GET' })
+}
+
+export async function apiPost(path, body) {
+  return fetchJSON(path, { method: 'POST', body })
+}
+
+export async function apiDownload(path, filename) {
+  const url = fullUrl(path)
+  const headers = await authHeader()
+  const res = await fetch(url, { headers })
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+  const blob = await res.blob()
+  const a = document.createElement('a')
+  a.href = URL.createObjectURL(blob)
+  a.download = filename || (url.split('/').pop() || 'download')
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(a.href)
+}
+
+/* ---------------- New structured API (can be used gradually) ---------------- */
 export const api = {
   // Auth / clients
-  getMe: (getToken) => fetchJSON('/auth/me', { getToken }),
-  getMyClients: (getToken) => fetchJSON('/clients/my', { getToken }),
+  getMe: () => apiGet('/auth/me'),
+  getMyClients: () => apiGet('/clients/my'),
 
   // Dashboard
-  getDashboardInterviews: (clientId, getToken) =>
-    fetchJSON(`/dashboard/interviews?client_id=${encodeURIComponent(clientId)}`, { getToken }),
+  getDashboardInterviews: (clientId) =>
+    apiGet(`/dashboard/interviews?client_id=${encodeURIComponent(clientId)}`),
 
   // Roles
-  createRole: (payload, getToken) =>
-    fetchJSON('/roles', { method: 'POST', body: payload, getToken }),
-  listRoles: (clientId, getToken) =>
-    fetchJSON(`/roles?client_id=${encodeURIComponent(clientId)}`, { getToken }),
+  createRole: (payload) => apiPost('/roles', payload),
+  listRoles: (clientId) => apiGet(`/roles?client_id=${encodeURIComponent(clientId)}`),
 
   // Files (signed URLs)
-  getSignedUrl: (interviewId, kind, getToken) =>
-    fetchJSON(`/files/signed-url?interview_id=${encodeURIComponent(interviewId)}&kind=${encodeURIComponent(kind)}`, { getToken }),
+  getSignedUrl: (interviewId, kind) =>
+    apiGet(`/files/signed-url?interview_id=${encodeURIComponent(interviewId)}&kind=${encodeURIComponent(kind)}`),
 
   // Reports
-  generateReport: (interviewId, getToken) =>
-    fetchJSON(`/reports/${encodeURIComponent(interviewId)}/generate`, { getToken }),
-  async downloadReport(interviewId, getToken) {
-    const url = `${base}/reports/${encodeURIComponent(interviewId)}/download`
-    const headers = await authHeader(getToken)
-    const res = await fetch(url, { headers })
-    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
-    const blob = await res.blob()
-    const a = document.createElement('a')
-    a.href = URL.createObjectURL(blob)
-    a.download = `report-${interviewId}.pdf`
-    document.body.appendChild(a)
-    a.click()
-    a.remove()
-    URL.revokeObjectURL(a.href)
-  },
+  generateReport: (interviewId) => apiGet(`/reports/${encodeURIComponent(interviewId)}/generate`),
+  downloadReport: (interviewId) => apiDownload(`/reports/${encodeURIComponent(interviewId)}/download`),
 
   // Invites + Members
-  createInvite: (payload, getToken) =>
-    fetchJSON('/clients/invite', { method: 'POST', body: payload, getToken }),
-  acceptInvite: (payload, getToken) =>
-    fetchJSON('/clients/accept-invite', { method: 'POST', body: payload, getToken }),
-  getMembers: (clientId, getToken) =>
-    fetchJSON(`/clients/members?client_id=${encodeURIComponent(clientId)}`, { getToken }),
-  revokeMember: (payload, getToken) =>
-    fetchJSON('/clients/members/revoke', { method: 'POST', body: payload, getToken }),
+  createInvite: (payload) => apiPost('/clients/invite', payload),
+  acceptInvite: (payload) => apiPost('/clients/accept-invite', payload),
+  getMembers: (clientId) => apiGet(`/clients/members?client_id=${encodeURIComponent(clientId)}`),
+  revokeMember: (payload) => apiPost('/clients/members/revoke', payload),
 }


### PR DESCRIPTION
No-op change to open a new PR. Includes:
Nav tabs: Roles, Candidates, Account.
Roles: list + create (client-scoped; JD text & manual Qs).
Candidates: dashboard; Transcript via signed URL; PDF via /reports/:id/download.
Account: members list, invite, revoke.
API: src/lib/api.js exports the structured api and legacy apiGet/apiDownload so older views build.
Config: requires VITE_BACKEND_URL, VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY.
Deploy note: set VITE_BACKEND_URL to the backend Render URL.