### PR TITLE
Admin: h2 section headers + 40px inputs

### DIFF
--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -367,7 +367,7 @@ export default function Admin() {
             <button className="toggle" onClick={() => setShowClients(v => !v)}>
               {showClients ? 'Hide clients' : 'Show clients'}
             </button>
-            <h3 className="section-title">Clients</h3>
+            <h2 className="section-title">Clients</h2>
           </div>
 
           <div className="row">
@@ -400,7 +400,7 @@ export default function Admin() {
             <button className="toggle" onClick={() => setShowRoles(v => !v)}>
               {showRoles ? 'Hide roles' : 'Show roles'}
             </button>
-            <h3 className="section-title">Roles</h3>
+            <h2 className="section-title">Roles</h2>
           </div>
 
           <div className="row">
@@ -477,7 +477,7 @@ export default function Admin() {
             <button className="toggle" onClick={() => setShowMembers(v => !v)}>
               {showMembers ? 'Hide members' : 'Show members'}
             </button>
-            <h3 className="section-title">Client Members</h3>
+            <h2 className="section-title">Client Members</h2>
           </div>
 
           <div className="row">

--- a/src/styles/alphaTheme.css
+++ b/src/styles/alphaTheme.css
@@ -237,7 +237,7 @@ button.danger {
 button.danger:hover { border-color: rgba(255, 80, 80, 0.9); }
 
 /* sizing: inputs & selects match height */
-.alpha-input { height: 40px; padding: 8px 10px; font-size: 14px; }
+input.alpha-input { height: 40px; padding: 8px 10px; font-size: 14px; }
 .alpha-select { height: 40px; }
 
 /* file input wrapper so clear icon can sit beside it */


### PR DESCRIPTION
Updates Admin.jsx to use <h2> for section titles and ensures input.alpha-input is 40px tall.