### PR TITLE
Admin: larger white trash icons + layout tweaks

### DIFF
--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -390,8 +390,8 @@ export default function Admin() {
                     <div className="title">{c.name}</div>
                     <div className="sub">Created {new Date(c.created_at).toLocaleString()}</div>
                   </div>
-                  <button className="btn-icon lilac" onClick={() => deleteClient(c.id)} title="Delete client">
-                    <IconTrash size={32} />
+                  <button className="btn-icon" onClick={() => deleteClient(c.id)} title="Delete client">
+                    <IconTrash size={36} />
                   </button>
                 </div>
               ))}
@@ -423,8 +423,8 @@ export default function Admin() {
                 aria-label="Job Description file (PDF or DOCX)"
               />
               {jobFile && (
-                <button className="btn-icon lilac file-clear" onClick={() => setJobFile(null)} title="Remove file">
-                  <IconTrash size={28} />
+                <button className="btn-icon file-clear" onClick={() => setJobFile(null)} title="Remove file">
+                  <IconTrash size={36} />
                 </button>
               )}
             </div>
@@ -467,8 +467,8 @@ export default function Admin() {
                         <button onClick={() => navigator.clipboard.writeText(`${shareBase}?role=${r.slug_or_token}`)}>Copy link</button>
                       </div>
                       <div className="center">
-                        <button className="btn-icon lilac" onClick={() => deleteRole(r.id)} title="Delete role">
-                          <IconTrash size={32} />
+                        <button className="btn-icon" onClick={() => deleteRole(r.id)} title="Delete role">
+                          <IconTrash size={36} />
                         </button>
                       </div>
                     </div>

--- a/src/styles/alphaTheme.css
+++ b/src/styles/alphaTheme.css
@@ -159,7 +159,11 @@
 }
 .section-title { font-size: 18px; font-weight: 700; }
 
+
 .section { margin-top: 12px; }
+
+/* helper: spacing for the Show/Hide toggle row beneath input rows */
+.toggle-row { margin-top: 8px; }
 
 .toggle {
   display: inline-flex;
@@ -264,16 +268,20 @@ button.danger:hover { border-color: rgba(255, 80, 80, 0.9); }
 
 /* lilac circular icon buttons; icon itself is white via SVG fill/stroke */
 .btn-icon.lilac {
-  background: #9d83f3;
+  background: transparent;
   border: none;
-  border-radius: 9999px;
-  width: 34px;
-  height: 34px;
+  border-radius: 0;
+  width: auto;
+  height: auto;
   display: inline-flex;
   align-items: center;
   justify-content: center;
 }
-.btn-icon.lilac:hover { filter: brightness(1.05); }
+.btn-icon.lilac svg {
+  width: 36px;
+  height: 36px;
+  stroke: #fff;
+}
 
 /* Header with logo + title (compact) */
 .alpha-header--dash { display:flex; align-items:center; justify-content:space-between; }


### PR DESCRIPTION
Plain white 36px trash icons for Clients/Roles; section button placement; all inputs 40px.