### PR TITLE
Tavus slot fill: crop letterboxing

### DIFF
--- a/src/styles/alphaTheme.css
+++ b/src/styles/alphaTheme.css
@@ -586,7 +586,31 @@ button.danger:hover { border-color: rgba(255, 80, 80, 0.9); }
   background: #000;          /* fallback behind video */
 }
 
-/* Make any injected iframe/video perfectly cover the slot */
+/* --- Tavus/Daily stage: fixed 16:9 box, centered --- */
+.interview-layout {
+  display: flex;
+  justify-content: center;
+}
+
+.tavus-stage {
+  position: relative;
+  /* target the “golden water” proportions */
+  width: min(62vw, 980px);
+  aspect-ratio: 16 / 9;          /* ⟵ this guarantees the height */
+  max-height: 560px;              /* ~980×553 reference */
+  margin: 24px auto;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #000;
+}
+
+/* Slot that Tavus/Daily mounts into */
+.tavus-slot {
+  position: absolute;
+  inset: 0;
+}
+
+/* Force the injected media to *stay inside* the box */
 .tavus-slot > iframe,
 .tavus-slot video,
 .tavus-slot [data-daily-video],
@@ -594,25 +618,13 @@ button.danger:hover { border-color: rgba(255, 80, 80, 0.9); }
   position: absolute !important;
   inset: 0 !important;
   width: 100% !important;
-  height: 100% !important;
+  height: 100% !important;  /* ⟵ kills the 3× tall issue */
   border: 0 !important;
   display: block;
   object-fit: cover;
 }
 
-/* If you show a placeholder loop before join, make it fill too */
-.tavus-slot .placeholder,
-.tavus-slot .placeholder video,
-.tavus-slot .placeholder img,
-.tavus-slot .placeholder canvas {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-/* Optional: keep the slot comfortably responsive on small screens */
+/* Optional: small screens keep it neat */
 @media (max-width: 640px) {
-  .tavus-slot { max-width: 100%; border-radius: 8px; }
+  .tavus-stage { width: 92vw; max-height: 56vw; border-radius: 8px; }
 }


### PR DESCRIPTION
CSS: overflow hidden on .tavus-slot and scale on child to fully cover the 16:9 stage.