### PR TITLE
Interview slot: crop-fill Daily/Tavus

### DIFF
--- a/src/styles/alphaTheme.css
+++ b/src/styles/alphaTheme.css
@@ -616,3 +616,37 @@ button.danger:hover { border-color: rgba(255, 80, 80, 0.9); }
 @media (max-width: 640px) {
   .tavus-stage { width: 92vw; max-height: 56vw; border-radius: 8px; }
 }
+
+/* --- Interview slot: make embedded Daily/Tavus fill the stage --- */
+.tavus-stage { /* your outer 16:9 wrapper; keep as-is if already present */
+  position: relative;
+}
+
+.tavus-slot {
+  position: relative;
+  overflow: hidden;           /* crop iframe chrome */
+  width: 100%;
+  aspect-ratio: 16 / 9;       /* keep the golden-water proportion */
+  max-width: min(960px, 86vw);
+  margin: 0 auto 24px;
+  border-radius: 12px;
+  background: #0e152b;
+}
+
+/* Fill + crop Daily/Tavus iframe so the video visually covers the slot */
+.tavus-slot > iframe {
+  position: absolute !important;
+  left: 0; top: -58px;        /* hide Daily top bar (~58px) */
+  width: 100% !important;
+  height: calc(100% + 120px) !important;  /* reclaim top+bottom toolbars */
+  border: 0;
+  display: block;
+}
+
+/* On wide screens, nudge right to hide the participant/sidebar strip */
+@media (min-width: 1024px) {
+  .tavus-slot > iframe {
+    right: -240px;            /* crop right sidebar (~240px) */
+    width: calc(100% + 240px) !important;
+  }
+}


### PR DESCRIPTION
CSS-only: overflow crop of Daily/Tavus iframe (hide top bar, tray, right sidebar) so speaker video fills 16:9 stage.