### PR TITLE
Tavus stage sizing: contain + taller slot

### DIFF
--- a/src/pages/InterviewAccessPage.jsx
+++ b/src/pages/InterviewAccessPage.jsx
@@ -186,6 +186,7 @@ export default function InterviewAccessPage() {
               src={roomUrl}
               loading="lazy"
               allow="camera; microphone; autoplay; fullscreen; display-capture; clipboard-write"
+              allowFullScreen
             />
           ) : (
             <div className="placeholder">
@@ -245,17 +246,24 @@ export default function InterviewAccessPage() {
         </div>
       </div>
       <style>{`
-        /* Tavus/Daily fixed 16:9 stage */
+        /* Tavus/Daily stage sizing: mobile keeps 16:9, desktop uses a fixed, shallower height */
         .tavus-stage { width: 100%; }
         .tavus-slot {
           position: relative;
           width: 100%;
-          /* 16:9 aspect ratio via padding-top */
-          padding-top: 56.25%;
           border-radius: 16px;
           border: 1px solid rgba(255,255,255,0.1);
           background: rgba(0,0,0,0.3);
           overflow: hidden;
+        }
+        /* Default (mobile-first): maintain 16:9 so small screens aren't too tall */
+        @media (max-width: 767px) {
+          .tavus-slot { aspect-ratio: 16 / 9; }
+        }
+        /* Desktop/tablet: match Tavus UI minimum so in-iframe controls aren't cropped */
+        @media (min-width: 768px) {
+          /* Match Tavus UI minimum so in-iframe controls aren't cropped */
+          .tavus-slot { height: 520px; }
         }
         /* Make any injected iframe/video perfectly cover the slot */
         .tavus-slot > iframe,
@@ -268,7 +276,8 @@ export default function InterviewAccessPage() {
           height: 100% !important;
           border: 0 !important;
           display: block;
-          object-fit: cover;
+          object-fit: contain;
+          background: #000;
         }
         /* Placeholder center message */
         .tavus-slot .placeholder {
@@ -282,7 +291,7 @@ export default function InterviewAccessPage() {
           text-align: center;
         }
         .tavus-slot .center-msg { max-width: 520px; }
-        /* Optional: keep the slot comfortably responsive on small screens */
+        /* Optional: keep the slot comfortably rounded on small screens */
         @media (max-width: 640px) {
           .tavus-slot { border-radius: 12px; }
         }

--- a/src/styles/alphaTheme.css
+++ b/src/styles/alphaTheme.css
@@ -589,6 +589,7 @@ button.danger:hover { border-color: rgba(255, 80, 80, 0.9); }
   margin: 24px auto;
   border-radius: 12px;
   overflow: hidden;
+  isolation: isolate;
   background: #000;
 }
 
@@ -596,6 +597,7 @@ button.danger:hover { border-color: rgba(255, 80, 80, 0.9); }
 .tavus-slot {
   position: absolute;
   inset: 0;
+  overflow: hidden;
 }
 
 /* Force the injected media to *stay inside* the box */
@@ -610,6 +612,20 @@ button.danger:hover { border-color: rgba(255, 80, 80, 0.9); }
   border: 0 !important;
   display: block;
   object-fit: contain;           /* show full UI without cropping */
+}
+
+/* Stronger catch-all for vendor iframes mounted into our slot */
+.tavus-stage iframe[src*="tavus."],
+.tavus-stage iframe[src*="daily.co"],
+#tavus-slot iframe {
+  position: absolute !important;
+  inset: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+  max-width: 100% !important;
+  max-height: 100% !important;
+  border: 0 !important;
+  display: block !important;
 }
 
 /* Optional: small screens keep it neat */


### PR DESCRIPTION
Increase desktop slot height to 520px, switch embedded media to object-fit: contain to avoid clipping, add black background and allowFullScreen.