### PR TITLE
Interview page visual tweaks (full-bleed + grid + Step 2)

### DIFF
--- a/src/components/InterviewAccessForm.jsx
+++ b/src/components/InterviewAccessForm.jsx
@@ -108,7 +108,7 @@ export default function InterviewAccessForm({ roleToken, onSubmitted }) {
 
   return (
     <form onSubmit={onSubmit} className="alpha-form-grid gap-y-4">
-      {/* First / Last */}
+      {/* Row 1: First / Last */}
       <div>
         <label className="alpha-label">First name</label>
         <input
@@ -132,7 +132,7 @@ export default function InterviewAccessForm({ roleToken, onSubmitted }) {
         />
       </div>
 
-      {/* Email (right column, wider) */}
+      {/* Row 2: Email (right column, 1.5fr) / Phone (right column) */}
       <div className="col-span-2 sm:col-start-2">
         <label className="alpha-label">Email</label>
         <input
@@ -144,8 +144,6 @@ export default function InterviewAccessForm({ roleToken, onSubmitted }) {
           className="alpha-input w-full"
         />
       </div>
-
-      {/* Phone (right column) */}
       <div className="col-span-2 sm:col-start-2">
         <label className="alpha-label">Phone</label>
         <input
@@ -163,7 +161,7 @@ export default function InterviewAccessForm({ roleToken, onSubmitted }) {
         />
       </div>
 
-      {/* Upload Resume button (left column), no label text above */}
+      {/* Row 3: Upload Resume (left column), no label text above */}
       <div>
         <button
           type="button"
@@ -185,7 +183,7 @@ export default function InterviewAccessForm({ roleToken, onSubmitted }) {
         />
       </div>
 
-      {/* Submit (right aligned with Verify) */}
+      {/* Row 3: Submit (right aligned with Verify in Step 2) */}
       <div className="col-span-2 sm:col-start-2 flex justify-end">
         <button
           type="submit"
@@ -197,7 +195,7 @@ export default function InterviewAccessForm({ roleToken, onSubmitted }) {
       </div>
 
       {/* Messages under grid */}
-      <div className="col-span-2">
+      <div className="alpha-col-span-2">
         {error && <p className="text-red-300 text-sm" role="alert">{error}</p>}
         {message && <p className="text-green-300 text-sm" role="status">{message}</p>}
       </div>

--- a/src/pages/InterviewAccessPage.jsx
+++ b/src/pages/InterviewAccessPage.jsx
@@ -17,6 +17,8 @@ const BK = (typeof import.meta !== 'undefined' && import.meta.env?.VITE_BACKEND_
   ? String(import.meta.env.VITE_BACKEND_URL).replace(/\/+$/, '')
   : '';
 
+// Step 2: OTP — email display removed; code field sits in column 1 width,
+// Verify button left-aligned with the code field; larger text via .btn-lg.
 function OtpInline({ email, candidateId, roleId, onVerified, onError }) {
   const [code, setCode] = useState('');
   const [busy, setBusy] = useState(false);
@@ -65,19 +67,8 @@ function OtpInline({ email, candidateId, roleId, onVerified, onError }) {
 
   return (
     <form onSubmit={submit} className="alpha-form-grid gap-y-3">
-      {/* Email (read-only) in right column to align with Step 1 */}
-      <div className="col-span-2 sm:col-start-2">
-        <label className="alpha-label">Email</label>
-        <input
-          type="email"
-          value={email}
-          readOnly
-          className="alpha-input w-full"
-        />
-      </div>
-
-      {/* 6-digit code (right column) */}
-      <div className="col-span-2 sm:col-start-2">
+      {/* 6-digit code — left column width */}
+      <div>
         <label className="alpha-label">6-digit code</label>
         <input
           type="text"
@@ -91,14 +82,14 @@ function OtpInline({ email, candidateId, roleId, onVerified, onError }) {
         />
       </div>
 
-      {/* Error/Success */}
-      <div className="col-span-2 sm:col-start-2">
+      {/* messages under the code field */}
+      <div className="alpha-col-span-2">
         {err && <p className="text-red-300 text-sm">{err}</p>}
         {msg && <p className="text-green-300 text-sm">{msg}</p>}
       </div>
 
-      {/* Verify button aligned right with Submit */}
-      <div className="col-span-2 sm:col-start-2 flex justify-end">
+      {/* Verify button — left aligned with the code field */}
+      <div>
         <button type="submit" disabled={busy} className="btn-lg">
           {busy ? 'Verifying…' : 'Verify'}
         </button>
@@ -210,7 +201,7 @@ export default function InterviewAccessPage() {
       <div className="space-y-6">
         {header}
 
-        {/* Full-bleed, opaque hallway hero */}
+        {/* Full-bleed, opaque hallway hero (no translucency, full width) */}
         <div className="alpha-hero fullbleed">
           <div className={`tavus-stage${prejoin ? ' prejoin' : ''}`} ref={roomRef}>
             <div
@@ -241,10 +232,9 @@ export default function InterviewAccessPage() {
           </div>
         </div>
 
-        {/* Same grid for Step 1 + Step 2 */}
+        {/* Step 1 + Step 2, on the same 2-col grid system */}
         <div className="alpha-form">
           <div className="grid grid-cols-1 gap-6 max-w-[1200px] mx-auto">
-            {/* Card-like surface just to match the theme (optional) */}
             <div className="space-y-8">
               {/* STEP 1 */}
               <div className="alpha-form-grid">
@@ -258,7 +248,7 @@ export default function InterviewAccessPage() {
                 />
               </div>
 
-              {/* STEP 2 (only shows after Step 1 submitted) */}
+              {/* STEP 2 */}
               <div className="space-y-3">
                 <h3 className="text-base font-semibold">Step 2 — Verify & Start</h3>
                 {!submitted ? (
@@ -278,9 +268,9 @@ export default function InterviewAccessPage() {
                       onError={() => setVerified(false)}
                     />
 
-                    {/* Start Interview appears ONLY after verified */}
+                    {/* Start Interview appears ONLY after verified; centered, white/lilac */}
                     {verified && (
-                      <div className="mt-2 flex justify-center">
+                      <div className="mt-2 start-block">
                         <button
                           type="button"
                           disabled={!canStart || starting}
@@ -299,7 +289,7 @@ export default function InterviewAccessPage() {
           </div>
         </div>
 
-        {/* local CSS specific to this page */}
+        {/* local CSS specific to this page (keeps Tavus sizing unchanged) */}
         <style>{`
           /* --- Tavus/Daily container --- */
           .tavus-stage { width: 100%; }
@@ -323,7 +313,7 @@ export default function InterviewAccessPage() {
             .tavus-slot { aspect-ratio: 16 / 9; }
           }
 
-          /* placeholder = fixed 1200×690 until roomUrl exists */
+          /* placeholder = fixed 1200×690 until roomUrl exists (do NOT change Tavus sizing) */
           .tavus-slot.no-room { height: 690px !important; }
 
           .tavus-slot > iframe,

--- a/src/styles/alphaTheme.css
+++ b/src/styles/alphaTheme.css
@@ -3,17 +3,18 @@
 
 /* alphaTheme.css (appenditions/overrides) */
 
-/* Full-bleed opaque hallway hero */
+/* Full-bleed opaque hallway hero (no translucency; spans entire viewport width) */
 .alpha-hero.fullbleed{
   position: relative;
   width: 100vw;
   margin-left: 50%;
   transform: translateX(-50%);
   background: url("/hallway.png") center/cover no-repeat; /* opaque */
-  padding: 150px 24px; /* ~25% taller than before; centers Tavus nicely */
+  /* keep the vertical rhythm you already had; if you want taller, adjust padding here */
+  /* padding: 150px 24px; */
 }
 
-/* Keep children constrained */
+/* Keep children constrained inside the hero */
 .alpha-hero.fullbleed .tavus-stage{ max-width: 1400px; margin: 0 auto; }
 
 /* Same two-column grid everywhere (1fr | 1.5fr) */
@@ -55,6 +56,7 @@
   color: #fff;
   border: 1px solid var(--alpha-primary);
   transition: filter .15s ease, background .15s ease, border-color .15s ease;
+  font-size: 1.05rem; /* larger text for Resume / Submit / Verify */
 }
 .btn-lg:hover{ background: var(--alpha-primary-strong); border-color: var(--alpha-primary-strong); }
 
@@ -66,7 +68,7 @@
   padding: 0 28px;
   border-radius: 32px;
   font-weight: 800;
-  font-size: 1.05rem;
+  font-size: 1.125rem; /* larger Start Interview */
 }
 
 /* White with lilac outline/text (Start Interview) */
@@ -128,7 +130,7 @@
   color:var(--alpha-darktext)!important;
 }
 
-/* buttons */
+/* buttons (base) */
 .alpha-theme button, .alpha-theme .btn, .alpha-theme input[type="button"], .alpha-theme input[type="submit"]{
   appearance:none; background:var(--alpha-primary); color:#fff; border:1px solid var(--alpha-primary);
   border-radius:20px; padding:8px 14px; font-weight:600; cursor:pointer;
@@ -137,7 +139,7 @@
   background:var(--alpha-primary-strong); border-color:var(--alpha-primary-strong);
 }
 
-/* inputs */
+/* inputs (base) */
 .alpha-theme input, .alpha-theme select, .alpha-theme textarea{
   background:rgba(255,255,255,0.08); color:var(--alpha-text); border:1px solid var(--alpha-border);
   border-radius:10px; padding:8px 10px;
@@ -146,13 +148,13 @@
 
 .alpha-theme select option{ color:#111; }
 
-/* ===== Hero (hallway.png) ================================================= */
+/* ===== Hero (legacy alpha-hero with translucent overlay — kept for other pages) */
 .alpha-hero{
   position:relative;
   max-width:1400px;
   margin:0 auto;
   border-radius:16px;
-  padding:96px 24px;             /* creates the banner height around the stage */
+  padding:96px 24px;             /* banner height */
   background:
     linear-gradient(rgba(6,21,81,0.82), rgba(6,21,81,0.82)),
     url("/hallway.png") center/cover no-repeat;
@@ -160,8 +162,6 @@
   isolation:isolate;
 }
 .alpha-hero .tavus-stage{ margin:0 auto; }
-
-/* spacing to the form block */
 .alpha-hero + .alpha-form{ margin-top:56px; }
 
 /* ===== Form container + grid ============================================= */
@@ -176,8 +176,6 @@
 @media (max-width: 768px){
   .alpha-form-grid{ grid-template-columns: 1fr; }
 }
-
-/* utility to place across both columns when needed */
 .alpha-col-span-2{ grid-column: 1 / -1; }
 
 /* inputs & buttons sized like the Wix mock */
@@ -190,6 +188,7 @@
   height:52px; border-radius:var(--alpha-radius);
   background:var(--alpha-surface); border:1px solid var(--alpha-border);
   color:var(--alpha-text); padding:10px 12px;
+  font-size: 1.05rem; /* slightly larger input text */
 }
 
 .alpha-form .btn-primary,
@@ -204,7 +203,7 @@
   background:var(--alpha-primary-strong); border-color:var(--alpha-primary-strong);
 }
 
-/* hide any native file inputs inside the form; we trigger via a styled button */
+/* hide any native file inputs; we trigger via a styled button */
 .alpha-form input[type="file"]{ display:none !important; }
 
 /* place the submit button bottom-right of the grid */
@@ -212,3 +211,24 @@
 
 /* small filename text under the resume button */
 .alpha-form .file-note{ margin-top:4px; font-size:12px; opacity:.8; }
+
+/* === Interview page final tweaks (append-only) =========================== */
+
+/* Ensure the full-bleed hero stays full width and opaque on the interview page */
+.alpha-hero.fullbleed{
+  position: relative;
+  width: 100vw;
+  margin-left: 50%;
+  transform: translateX(-50%);
+  background: url("/hallway.png") center/cover no-repeat;
+}
+
+/* Add ~20px between col 1 and col 2 so columns never touch */
+.alpha-form-grid { gap: 20px !important; }
+
+/* Centered block for Start Interview + bottom padding */
+.start-block {
+  display: flex;
+  justify-content: center;
+  padding-bottom: 24px;
+}


### PR DESCRIPTION
Full-bleed opaque hallway, non-overlapping columns, Step 2 email removed + code on col1, larger button typography, centered white Start Interview. No Tavus sizing changes.