### PR TITLE
Client Sign In: match Admin spacing/position

### DIFF
--- a/src/styles/clientTheme.css
+++ b/src/styles/clientTheme.css
@@ -4,7 +4,7 @@
 /* Theme variables come from the global alpha theme; we only style the auth card */
 .client-auth .alpha-card.auth-wrap.client-card {
   max-width: 480px;
-  margin: 80px auto 0;
+  margin: 12vh auto 8vh;
   padding: 24px;
   background: var(--alpha-surface) !important;
   border: 1px solid var(--alpha-border) !important;
@@ -33,7 +33,7 @@
   width: 100% !important;
   max-width: 100% !important;
   display: block;
-  margin-bottom: 8px;
+  margin-bottom: 10px;
 }
 .client-auth button[type="submit"] {
   width: 100%;


### PR DESCRIPTION
Sets auth card margin to 12vh auto 8vh and increases input spacing to mirror Admin.